### PR TITLE
Add EPAM Services Test

### DIFF
--- a/tests/epam_services_test.ts
+++ b/tests/epam_services_test.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('EPAM Services Test', () => {
+  test('Navigate to EPAM services and verify client work', async ({ page }) => {
+    // Navigate to EPAM website
+    await page.goto('https://www.epam.com/');
+
+    // Select "Services" from the header menu
+    await page.click('text=Services');
+
+    // Click the "Explore Our Client Work" link
+    await page.click('text=Explore Our Client Work');
+
+    // Verify the visibility of the "Client Work" text
+    const clientWorkText = await page.locator('text=Client Work').first();
+    await expect(clientWorkText).toBeVisible();
+  });
+});


### PR DESCRIPTION
This pull request adds a new Playwright test for the EPAM services scenario. The test performs the following actions:

1. Navigates to https://www.epam.com/
2. Selects "Services" from the header menu
3. Clicks the "Explore Our Client Work" link
4. Verifies the visibility of the "Client Work" text

This test case demonstrates basic navigation and element interaction using Playwright.

To run this test:
1. Ensure you have Playwright installed: `npm install @playwright/test`
2. Run the test using: `npx playwright test tests/epam_services_test.ts`

Future Enhancements:
- Add more detailed assertions
- Implement error handling for network issues or element timeouts
- Create a reusable Page Object Model for EPAM website interactions

Please review and provide any feedback or suggestions for improvements.