### PR TITLE
Add EPAM Services and Client Work Navigation Test

### DIFF
--- a/tests/epam-services.test.ts
+++ b/tests/epam-services.test.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test';
+
+test('EPAM Services and Client Work Navigation', async ({ page }) => {
+  // Navigate to EPAM website
+  await page.goto('https://www.epam.com/');
+
+  // Select "Services" from the header menu
+  await page.click('text=Services');
+
+  // Click the "Explore Our Client Work" link
+  await page.click('text=Explore Our Client Work');
+
+  // Verify that the "Client Work" text is visible on the page
+  await expect(page.locator('text=Client Work')).toBeVisible();
+});


### PR DESCRIPTION
This pull request adds a new Playwright test for navigating the EPAM website, specifically testing the Services and Client Work sections.

The test performs the following steps:
1. Navigates to https://www.epam.com/
2. Selects "Services" from the header menu
3. Clicks the "Explore Our Client Work" link
4. Verifies that the "Client Work" text is visible on the page

This test enhances our automated testing coverage for the EPAM website's core navigation and content visibility.