### PR TITLE
Add EPAM Services and Client Work Navigation Test

### DIFF
--- a/tests/epam-services.spec.ts
+++ b/tests/epam-services.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test';
+
+test('EPAM Services and Client Work Navigation', async ({ page }) => {
+  // Navigate to EPAM website
+  await page.goto('https://www.epam.com/');
+
+  // Select "Services" from the header menu
+  await page.click('text=Services');
+
+  // Click the "Explore Our Client Work" link
+  await page.click('text=Explore Our Client Work');
+
+  // Verify that the "Client Work" text is visible on the page
+  await expect(page.locator('text=Client Work')).toBeVisible();
+});


### PR DESCRIPTION
This pull request adds a new Playwright test for navigating through EPAM's Services and Client Work pages.

The test performs the following steps:
1. Navigates to https://www.epam.com/
2. Selects "Services" from the header menu
3. Clicks the "Explore Our Client Work" link
4. Verifies that the "Client Work" text is visible on the page

This test helps ensure that the basic navigation and content visibility on these important pages are working as expected.

To run this test locally:
1. Ensure you have Node.js and npm installed
2. Install dependencies: `npm install`
3. Install Playwright browsers: `npx playwright install`
4. Run the test: `npx playwright test tests/epam-services.spec.ts`

Please review and provide any feedback or suggestions for improvements.