### PR TITLE
Add EPAM Client Work Test Scenario

### DIFF
--- a/tests/epam-client-work.spec.ts
+++ b/tests/epam-client-work.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+import { EpamPage } from './pages/EpamPage';
+
+test.describe('EPAM Client Work Test', () => {
+  let epamPage: EpamPage;
+
+  test.beforeEach(async ({ page }) => {
+    epamPage = new EpamPage(page);
+  });
+
+  test('Navigate to Client Work page and verify content', async () => {
+    // Navigate to EPAM website
+    await epamPage.navigateTo();
+
+    // Select "Services" from the header menu
+    await epamPage.clickServicesMenuItem();
+
+    // Click the "Explore Our Client Work" link
+    await epamPage.clickExploreClientWorkLink();
+
+    // Verify that the "Client Work" text is visible on the page
+    const isClientWorkTextVisible = await epamPage.isClientWorkTextVisible();
+    expect(isClientWorkTextVisible).toBe(true, 'Client Work text should be visible on the page');
+  });
+
+  test('Verify navigation to Client Work page from homepage', async () => {
+    // Navigate to EPAM website
+    await epamPage.navigateTo();
+
+    // Verify that the "Explore Our Client Work" link is visible on the homepage
+    const isExploreClientWorkLinkVisible = await epamPage.exploreClientWorkLink.isVisible();
+    expect(isExploreClientWorkLinkVisible).toBe(true, 'Explore Our Client Work link should be visible on the homepage');
+
+    // Click the "Explore Our Client Work" link
+    await epamPage.clickExploreClientWorkLink();
+
+    // Verify that the "Client Work" text is visible on the page
+    const isClientWorkTextVisible = await epamPage.isClientWorkTextVisible();
+    expect(isClientWorkTextVisible).toBe(true, 'Client Work text should be visible on the page');
+  });
+});

--- a/tests/pages/EpamPage.ts
+++ b/tests/pages/EpamPage.ts
@@ -1,0 +1,31 @@
+import { Page, Locator } from '@playwright/test';
+
+export class EpamPage {
+  readonly page: Page;
+  readonly servicesMenuItem: Locator;
+  readonly exploreClientWorkLink: Locator;
+  readonly clientWorkText: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.servicesMenuItem = page.locator('header a:text("Services")');
+    this.exploreClientWorkLink = page.locator('a:text("Explore Our Client Work")');
+    this.clientWorkText = page.locator('text="Client Work"');
+  }
+
+  async navigateTo() {
+    await this.page.goto('https://www.epam.com/');
+  }
+
+  async clickServicesMenuItem() {
+    await this.servicesMenuItem.click();
+  }
+
+  async clickExploreClientWorkLink() {
+    await this.exploreClientWorkLink.click();
+  }
+
+  async isClientWorkTextVisible() {
+    return await this.clientWorkText.isVisible();
+  }
+}


### PR DESCRIPTION
This pull request adds a Playwright test scenario for navigating to the EPAM Client Work page and verifying its content. The changes include:

1. Creation of a Page Object Model (EpamPage.ts) for the EPAM website.
2. Implementation of a test file (epam-client-work.spec.ts) with two test cases:
   a. Navigate to Client Work page through the Services menu.
   b. Verify navigation to Client Work page directly from the homepage.

The test scenario follows clean coding principles and uses the Page Object Model for better maintainability and readability.

Changes:
- Added `tests/pages/EpamPage.ts`
- Added `tests/epam-client-work.spec.ts`

Please review and provide feedback.