### PR TITLE
Add EPAM website navigation test

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,20 @@
+import { PlaywrightTestConfig } from '@playwright/test';
+
+const config: PlaywrightTestConfig = {
+  testDir: './tests',
+  timeout: 30000,
+  use: {
+    headless: false,
+    viewport: { width: 1280, height: 720 },
+    ignoreHTTPSErrors: true,
+    video: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { browserName: 'chromium' },
+    },
+  ],
+};
+
+export default config;

--- a/tests/epam.spec.ts
+++ b/tests/epam.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+import { HomePage } from './pages/HomePage';
+
+test.describe('EPAM Website Navigation', () => {
+  let homePage: HomePage;
+
+  test.beforeEach(async ({ page }) => {
+    homePage = new HomePage(page);
+  });
+
+  test('Navigate to Client Work page', async () => {
+    // Navigate to EPAM homepage
+    await homePage.navigateTo();
+
+    // Click on Services menu
+    await homePage.clickServicesMenu();
+
+    // Click on Explore Our Client Work link
+    await homePage.clickExploreClientWork();
+
+    // Verify that Client Work text is visible
+    const isClientWorkVisible = await homePage.isClientWorkTextVisible();
+    expect(isClientWorkVisible).toBe(true, 'Client Work text should be visible on the page');
+  });
+});

--- a/tests/pages/HomePage.ts
+++ b/tests/pages/HomePage.ts
@@ -1,0 +1,25 @@
+import { Page } from '@playwright/test';
+
+export class HomePage {
+  private page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  async navigateTo() {
+    await this.page.goto('https://www.epam.com/');
+  }
+
+  async clickServicesMenu() {
+    await this.page.click('text=Services');
+  }
+
+  async clickExploreClientWork() {
+    await this.page.click('text=Explore Our Client Work');
+  }
+
+  async isClientWorkTextVisible() {
+    return await this.page.isVisible('text=Client Work');
+  }
+}


### PR DESCRIPTION
This PR adds a Playwright test scenario for navigating the EPAM website and verifying the Client Work page.

Changes include:
- Created a Page Object Model for the EPAM homepage (tests/pages/HomePage.ts)
- Implemented a test scenario for navigating to the Client Work page (tests/epam.spec.ts)
- Added a basic Playwright configuration file (playwright.config.ts)

The test follows clean coding principles and uses the Page Object Model pattern for better maintainability and readability.

To run the tests:
1. Install dependencies: `npm install`
2. Run the test: `npx playwright test`

Please review and provide feedback.