### PR TITLE
Add EPAM Services Navigation Test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "web-testing-automation",
+  "version": "1.0.0",
+  "description": "Web Testing Automation Project",
+  "main": "index.js",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "test:debug": "playwright test --debug"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@playwright/test": "^1.32.3",
+    "@types/node": "^18.15.11",
+    "typescript": "^5.0.4"
+  }
+}

--- a/tests/epam-services.spec.ts
+++ b/tests/epam-services.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+import { EpamHomePage } from './pages/EpamHomePage';
+
+test.describe('EPAM Services Navigation', () => {
+  let epamHomePage: EpamHomePage;
+
+  test.beforeEach(async ({ page }) => {
+    epamHomePage = new EpamHomePage(page);
+  });
+
+  test('Navigate to Client Work page', async () => {
+    // Navigate to EPAM homepage
+    await epamHomePage.navigateTo();
+
+    // Click on Services menu
+    await epamHomePage.clickServicesMenu();
+
+    // Click on Explore Our Client Work link
+    await epamHomePage.clickExploreClientWork();
+
+    // Verify that the "Client Work" text is visible on the page
+    const isClientWorkVisible = await epamHomePage.isClientWorkTextVisible();
+    expect(isClientWorkVisible).toBe(true, 'Client Work text should be visible on the page');
+  });
+});

--- a/tests/pages/EpamHomePage.ts
+++ b/tests/pages/EpamHomePage.ts
@@ -1,0 +1,25 @@
+import { Page } from '@playwright/test';
+
+export class EpamHomePage {
+  private page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  async navigateTo() {
+    await this.page.goto('https://www.epam.com/');
+  }
+
+  async clickServicesMenu() {
+    await this.page.click('text=Services');
+  }
+
+  async clickExploreClientWork() {
+    await this.page.click('text=Explore Our Client Work');
+  }
+
+  async isClientWorkTextVisible() {
+    return await this.page.isVisible('text=Client Work');
+  }
+}


### PR DESCRIPTION
This PR adds a Playwright test scenario for navigating to the EPAM Services page and verifying the "Client Work" text visibility.

Changes include:
- Created EpamHomePage.ts for Page Object Model
- Created epam-services.spec.ts for the test scenario
- Updated package.json with Playwright dependencies and test scripts

To run the tests locally:
1. Install dependencies: `npm install`
2. Run tests: `npm test`
3. Run tests in headed mode: `npm run test:headed`
4. Run tests in debug mode: `npm run test:debug`