### PR TITLE
Add Playwright Testing Framework for EPAM Services Page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "epam-services-test",
+  "version": "1.0.0",
+  "description": "Playwright tests for EPAM Services page",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "keywords": ["playwright", "testing", "typescript"],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@playwright/test": "^1.32.3",
+    "playwright": "^1.32.3",
+    "typescript": "^4.9.5"
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,27 @@
+import { PlaywrightTestConfig } from '@playwright/test';
+
+const config: PlaywrightTestConfig = {
+  testDir: './tests',
+  timeout: 30000,
+  use: {
+    headless: true,
+    viewport: { width: 1280, height: 720 },
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { browserName: 'chromium' },
+    },
+    {
+      name: 'firefox',
+      use: { browserName: 'firefox' },
+    },
+    {
+      name: 'webkit',
+      use: { browserName: 'webkit' },
+    },
+  ],
+};
+
+export default config;

--- a/tests/epam-services.spec.ts
+++ b/tests/epam-services.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('EPAM Services Page Test', () => {
+  test('Navigate to Client Work section', async ({ page }) => {
+    // Navigate to EPAM website
+    await page.goto('https://www.epam.com/');
+
+    // Select "Services" from the header menu
+    await page.click('text=Services');
+
+    // Click the "Explore Our Client Work" link
+    await page.click('text=Explore Our Client Work');
+
+    // Verify the visibility of the "Client Work" text
+    const clientWorkText = await page.locator('text=Client Work').first();
+    await expect(clientWorkText).toBeVisible();
+
+    // Additional assertion: Check if we're on the correct page
+    await expect(page).toHaveURL(/.*our-work/);
+  });
+});


### PR DESCRIPTION
This pull request adds a Playwright testing framework with TypeScript for testing the EPAM Services page. The following changes have been made:

1. Added `playwright.config.ts` with configuration for running tests in Chromium, Firefox, and WebKit.
2. Created a test file `tests/epam-services.spec.ts` that navigates to the EPAM website, clicks on the Services menu, explores client work, and verifies the presence of "Client Work" text.
3. Updated `package.json` with necessary dependencies and test script.

Local testing has been performed, and all tests pass successfully. This framework provides a solid foundation for further test development and automation.

To run the tests locally:
1. Install dependencies: `npm install`
2. Run tests: `npm test`

Please review and provide feedback.