### PR TITLE
Add EPAM website automated tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+test-results/
+playwright-report/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# web-testing-automation
+# EPAM Website Test Automation
+
+This project contains automated tests for the EPAM website using Playwright and TypeScript.
+
+## Test Scenario
+
+The test performs the following actions:
+1. Navigate to https://www.epam.com/
+2. Select "Services" from the header menu
+3. Click the "Explore Our Client Work" link
+4. Verify the visibility of the "Client Work" text
+
+## Running the Tests
+
+To run the tests, follow these steps:
+
+1. Install dependencies:
+   ```
+   npm install
+   ```
+
+2. Run the tests:
+   ```
+   npm test
+   ```
+
+This will execute the tests in Chromium, Firefox, and WebKit browsers.
+
+## Test Results
+
+The tests will generate a report in the `playwright-report` directory. You can view this report by opening the `index.html` file in your browser.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "epam-test-project",
+  "version": "1.0.0",
+  "description": "Playwright tests for EPAM website",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.32.0",
+    "@types/node": "^18.15.11",
+    "typescript": "^5.0.3"
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,27 @@
+import { PlaywrightTestConfig } from '@playwright/test';
+
+const config: PlaywrightTestConfig = {
+  testDir: './tests',
+  timeout: 30000,
+  use: {
+    headless: true,
+    viewport: { width: 1280, height: 720 },
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { browserName: 'chromium' },
+    },
+    {
+      name: 'firefox',
+      use: { browserName: 'firefox' },
+    },
+    {
+      name: 'webkit',
+      use: { browserName: 'webkit' },
+    },
+  ],
+};
+
+export default config;

--- a/tests/epam.spec.ts
+++ b/tests/epam.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+test('EPAM website navigation and verification', async ({ page }) => {
+  // Navigate to EPAM website
+  await page.goto('https://www.epam.com/');
+
+  // Select "Services" from the header menu
+  await page.click('text=Services');
+
+  // Click the "Explore Our Client Work" link
+  await page.click('text=Explore Our Client Work');
+
+  // Verify the visibility of the "Client Work" text
+  const clientWorkText = await page.locator('text=Client Work').first();
+  await expect(clientWorkText).toBeVisible();
+});


### PR DESCRIPTION
This PR adds automated tests for the EPAM website using Playwright and TypeScript.

Changes include:
- Setup Playwright testing framework
- Implement test scenario for EPAM website navigation
- Configure multi-browser testing (Chromium, Firefox, WebKit)
- Add documentation for running tests

The tests have been validated locally and pass successfully across all specified browsers.

To review:
1. Check the test implementation in `tests/epam.spec.ts`
2. Review the project configuration in `playwright.config.ts`
3. Ensure the README.md provides clear instructions for running tests

Please let me know if any changes or additional tests are needed.