### PR TITLE
Add Playwright TypeScript framework for EPAM website testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+test-results/
+playwright-report/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "epam-test-project",
+  "version": "1.0.0",
+  "description": "Playwright tests for EPAM website",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.32.0",
+    "typescript": "^4.9.5"
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,27 @@
+import { PlaywrightTestConfig } from '@playwright/test';
+
+const config: PlaywrightTestConfig = {
+  testDir: './tests',
+  timeout: 30000,
+  use: {
+    headless: false,
+    viewport: { width: 1280, height: 720 },
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { browserName: 'chromium' },
+    },
+    {
+      name: 'firefox',
+      use: { browserName: 'firefox' },
+    },
+    {
+      name: 'webkit',
+      use: { browserName: 'webkit' },
+    },
+  ],
+};
+
+export default config;

--- a/tests/epam.spec.ts
+++ b/tests/epam.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test';
+
+test('EPAM Services and Client Work Navigation', async ({ page }) => {
+  // Navigate to https://www.epam.com/
+  await page.goto('https://www.epam.com/');
+
+  // Select "Services" from the header menu
+  await page.click('text=Services');
+
+  // Click the "Explore Our Client Work" link
+  await page.click('text=Explore Our Client Work');
+
+  // Verify that the "Client Work" text is visible on the page
+  await expect(page.locator('text=Client Work')).toBeVisible();
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}


### PR DESCRIPTION
This pull request adds a Playwright TypeScript framework for testing the EPAM website. The framework includes the following files:

- package.json: Defines project dependencies and scripts
- tsconfig.json: TypeScript configuration
- playwright.config.ts: Playwright test configuration
- tests/epam.spec.ts: Test file for the EPAM website scenario
- .gitignore: Specifies files and directories to be ignored by Git

The test scenario covers the following steps:
1. Navigate to https://www.epam.com/
2. Select "Services" from the header menu
3. Click the "Explore Our Client Work" link
4. Verify that the "Client Work" text is visible on the page

To run the tests locally:
1. Install dependencies: `npm install`
2. Install Playwright browsers: `npx playwright install`
3. Run tests: `npm test`

Please review and provide feedback. Once approved, we can merge this into the main branch to establish our Playwright testing framework.