### PR TITLE
Add EPAM Client Work Test Scenario

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,17 @@
+import { PlaywrightTestConfig } from '@playwright/test';
+
+const config: PlaywrightTestConfig = {
+  testDir: './tests',
+  timeout: 30000,
+  use: {
+    headless: false,
+    viewport: { width: 1280, height: 720 },
+    screenshot: 'only-on-failure',
+  },
+  reporter: [
+    ['html'],
+    ['allure-playwright'],
+  ],
+};
+
+export default config;

--- a/tests/epam.spec.ts
+++ b/tests/epam.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+import { EpamPage } from './pages/EpamPage';
+
+test.describe('EPAM Website Tests', () => {
+  let epamPage: EpamPage;
+
+  test.beforeEach(async ({ page }) => {
+    epamPage = new EpamPage(page);
+  });
+
+  test('Navigate to Client Work page', async () => {
+    // Navigate to the EPAM homepage
+    await epamPage.navigateToHomepage();
+
+    // Click on the Services menu
+    await epamPage.clickServicesMenu();
+
+    // Click on the "Explore Our Client Work" link
+    await epamPage.clickExploreClientWork();
+
+    // Verify that the "Client Work" text is visible on the page
+    const isClientWorkVisible = await epamPage.isClientWorkTextVisible();
+    expect(isClientWorkVisible).toBe(true, 'Client Work text should be visible on the page');
+  });
+});

--- a/tests/pages/EpamPage.ts
+++ b/tests/pages/EpamPage.ts
@@ -1,0 +1,25 @@
+import { Page } from '@playwright/test';
+
+export class EpamPage {
+  private page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  async navigateToHomepage() {
+    await this.page.goto('https://www.epam.com/');
+  }
+
+  async clickServicesMenu() {
+    await this.page.click('text=Services');
+  }
+
+  async clickExploreClientWork() {
+    await this.page.click('text=Explore Our Client Work');
+  }
+
+  async isClientWorkTextVisible() {
+    return await this.page.isVisible('text="Client Work"');
+  }
+}


### PR DESCRIPTION
This PR adds a Playwright test scenario for navigating to the EPAM Client Work page and verifying its content. The changes include:

1. Creation of a Page Object Model for the EPAM website (EpamPage.ts)
2. Implementation of the test scenario (epam.spec.ts)
3. Addition of a Playwright configuration file (playwright.config.ts)

The test follows clean coding principles and uses the Page Object Model for better maintainability and readability.

To run the tests:
1. Install dependencies: `npm install`
2. Run the test: `npx playwright test`

Please review and provide feedback.