### PR TITLE
Add Client Work page test

### DIFF
--- a/tests/clientWorkTest.spec.ts
+++ b/tests/clientWorkTest.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+import { EpamHomePage } from './pageObjects/EpamHomePage';
+import { ClientWorkPage } from './pageObjects/ClientWorkPage';
+
+test('Navigate to Client Work page and verify content', async ({ page }) => {
+  const epamHomePage = new EpamHomePage(page);
+  const clientWorkPage = new ClientWorkPage(page);
+
+  // Navigate to EPAM homepage
+  await epamHomePage.goto();
+
+  // Select "Services" from the header menu
+  await epamHomePage.selectServices();
+
+  // Click the "Explore Our Client Work" link
+  await epamHomePage.clickExploreClientWork();
+
+  // Verify that the "Client Work" text is visible on the page
+  await clientWorkPage.verifyClientWorkText();
+});

--- a/tests/pageObjects/ClientWorkPage.ts
+++ b/tests/pageObjects/ClientWorkPage.ts
@@ -1,0 +1,13 @@
+import { Page } from '@playwright/test';
+
+export class ClientWorkPage {
+  readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  async verifyClientWorkText() {
+    await expect(this.page.locator('text=Client Work')).toBeVisible();
+  }
+}

--- a/tests/pageObjects/EpamHomePage.ts
+++ b/tests/pageObjects/EpamHomePage.ts
@@ -1,0 +1,21 @@
+import { Page } from '@playwright/test';
+
+export class EpamHomePage {
+  readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  async goto() {
+    await this.page.goto('https://www.epam.com/');
+  }
+
+  async selectServices() {
+    await this.page.locator('text=Services').click();
+  }
+
+  async clickExploreClientWork() {
+    await this.page.locator('text=Learn More').click();
+  }
+}


### PR DESCRIPTION
This PR adds a test scenario for navigating to the Client Work page and verifying the presence of the "Client Work" text. It includes the following changes:
- Added a test file `clientWorkTest.spec.ts`
- Added Page Object Model files `EpamHomePage.ts` and `ClientWorkPage.ts`
- Ensured clean coding principles and SOLID principles are followed